### PR TITLE
Simple scene rotation

### DIFF
--- a/example-applications/iot-lifx-controller/pom.xml
+++ b/example-applications/iot-lifx-controller/pom.xml
@@ -69,5 +69,10 @@
             <artifactId>slf4j-log4j12</artifactId>
             <version>1.7.12</version>
         </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sqs</artifactId>
+            <version>1.10.27</version>
+        </dependency>
     </dependencies>
 </project>

--- a/example-applications/iot-lifx-controller/src/main/java/com/timmattison/IotLifxController.java
+++ b/example-applications/iot-lifx-controller/src/main/java/com/timmattison/IotLifxController.java
@@ -2,6 +2,7 @@ package com.timmattison;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
 import com.timmattison.button.IotButtonData;
 import com.timmattison.configuration.Configuration;
 import com.timmattison.guice.SharedInjector;
@@ -15,6 +16,9 @@ import java.util.HashMap;
  * Created by timmattison on 10/16/15.
  */
 public class IotLifxController {
+    public static final String DETAIL_TYPE = "detail-type";
+    public static final String SCHEDULED_EVENT = "Scheduled Event";
+
     private final Configuration configuration = SharedInjector.getInjector().getInstance(Configuration.class);
     private final LifxController lifxController = SharedInjector.getInjector().getInstance(LifxController.class);
 
@@ -28,6 +32,11 @@ public class IotLifxController {
      * @throws IOException
      */
     public String handleRequest(HashMap request, Context context) throws IOException {
+        if ((request.containsKey(DETAIL_TYPE)) && (request.get(DETAIL_TYPE).equals(SCHEDULED_EVENT))) {
+            // This is a scheduled job just to keep the system warm.  Return immediately.
+            return SCHEDULED_EVENT;
+        }
+
         // Convert the request into the IOT button data structure
         IotButtonData iotButtonData = new IotButtonData(ImmutableMap.copyOf(request));
 

--- a/example-applications/iot-lifx-controller/src/main/java/com/timmattison/configuration/BasicSceneRotatorPersistence.java
+++ b/example-applications/iot-lifx-controller/src/main/java/com/timmattison/configuration/BasicSceneRotatorPersistence.java
@@ -1,0 +1,75 @@
+package com.timmattison.configuration;
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.AmazonSQSClient;
+import com.amazonaws.services.sqs.model.*;
+import com.timmattison.lifx.Scene;
+import com.timmattison.lifx.SceneList;
+
+import java.util.List;
+
+/**
+ * Created by timmattison on 10/22/15.
+ */
+public class BasicSceneRotatorPersistence implements SceneRotatorPersistence {
+    public static final String IOT_LIFX_CONTROLLER_QUEUE_PREFIX = "iot-lifx-controller";
+
+    public Scene getNextScene(SceneList sceneList) {
+        // Get our credentials
+        AWSCredentials credentials = null;
+        try {
+            credentials = new EnvironmentVariableCredentialsProvider().getCredentials();
+        } catch (Exception e) {
+            throw new AmazonClientException(
+                    "Cannot load the credentials from the credential profiles file. " +
+                            "Please make sure that your credentials file is at the correct " +
+                            "location (~/.aws/credentials), and is in valid format.",
+                    e);
+        }
+
+        // Get an SQS client for the US-East-1 region
+        AmazonSQS sqs = new AmazonSQSClient(credentials);
+        Region usEast1 = Region.getRegion(Regions.US_EAST_1);
+        sqs.setRegion(usEast1);
+
+        // Create a queue for temporary storage if it doesn't exist already
+        int sceneListHashCode = Math.abs(sceneList.hashCode());
+        CreateQueueRequest createQueueRequest = new CreateQueueRequest(IOT_LIFX_CONTROLLER_QUEUE_PREFIX + "-" + sceneListHashCode);
+        String queueUrl = sqs.createQueue(createQueueRequest).getQueueUrl();
+
+        // Get any messages out of the queue.  Hopefully there's only one but it doesn't really matter.
+        ReceiveMessageRequest receiveMessageRequest = new ReceiveMessageRequest(queueUrl);
+        List<Message> messages = sqs.receiveMessage(receiveMessageRequest).getMessages();
+
+        String lastBody = null;
+
+        // Loop through, grab the state info, and delete the messages
+        for (Message message : messages) {
+            lastBody = message.getBody();
+
+            String messageReceiptHandle = message.getReceiptHandle();
+            sqs.deleteMessage(new DeleteMessageRequest(queueUrl, messageReceiptHandle));
+        }
+
+        // Get the list of scenes
+        List<String> uuids = sceneList.getScenes();
+
+        // Find the index of the last scene we used.  If we can't find it we'll get -1, which is OK.
+        int lastSceneIndex = uuids.indexOf(lastBody);
+
+        // Go to the next scene in the list, or go to the first scene in the list if lastSceneIndex is -1
+        int nextSceneIndex = (lastSceneIndex + 1) % uuids.size();
+
+        // Get the string for the next scene and persist it back into the queue as our last scene
+        String nextScene = uuids.get(nextSceneIndex);
+        sqs.sendMessage(new SendMessageRequest(queueUrl, nextScene));
+
+        // Return the scene
+        return new Scene(nextScene);
+    }
+}

--- a/example-applications/iot-lifx-controller/src/main/java/com/timmattison/configuration/SceneRotatorPersistence.java
+++ b/example-applications/iot-lifx-controller/src/main/java/com/timmattison/configuration/SceneRotatorPersistence.java
@@ -1,0 +1,11 @@
+package com.timmattison.configuration;
+
+import com.timmattison.lifx.Scene;
+import com.timmattison.lifx.SceneList;
+
+/**
+ * Created by timmattison on 10/22/15.
+ */
+public interface SceneRotatorPersistence {
+    Scene getNextScene(SceneList sceneList);
+}

--- a/example-applications/iot-lifx-controller/src/main/java/com/timmattison/guice/LambdaModule.java
+++ b/example-applications/iot-lifx-controller/src/main/java/com/timmattison/guice/LambdaModule.java
@@ -1,8 +1,10 @@
 package com.timmattison.guice;
 
 import com.google.inject.AbstractModule;
+import com.timmattison.configuration.BasicSceneRotatorPersistence;
 import com.timmattison.configuration.Configuration;
 import com.timmattison.configuration.ConfigurationFromTypeSafe;
+import com.timmattison.configuration.SceneRotatorPersistence;
 import com.timmattison.lifx.BasicLifxController;
 import com.timmattison.lifx.LifxController;
 
@@ -17,5 +19,8 @@ public class LambdaModule extends AbstractModule {
 
         // Use the basic implementation of the LIFX controller
         bind(LifxController.class).to(BasicLifxController.class);
+
+        // Use the basic scene rotator
+        bind(SceneRotatorPersistence.class).to(BasicSceneRotatorPersistence.class);
     }
 }

--- a/example-applications/iot-lifx-controller/src/main/java/com/timmattison/lifx/Action.java
+++ b/example-applications/iot-lifx-controller/src/main/java/com/timmattison/lifx/Action.java
@@ -1,8 +1,7 @@
 package com.timmattison.lifx;
 
-import com.google.common.collect.ImmutableMap;
+import com.typesafe.config.ConfigList;
 import com.typesafe.config.ConfigObject;
-import com.typesafe.config.ConfigValue;
 
 /**
  * Created by timmattison on 10/17/15.
@@ -44,5 +43,19 @@ public class Action {
 
         // Return the configuration as a state object
         return new State(innerConfigObject);
+    }
+
+    public SceneList getSceneList() {
+        // Is there a scene list in the config?
+        if (!configObject.containsKey(sceneList)) {
+            // No, return NULL
+            return null;
+        }
+
+        // Extract the state configuration
+        ConfigList innerConfigList = (ConfigList) configObject.get(sceneList);
+
+        // Return the configuration as a state object
+        return new SceneList(innerConfigList);
     }
 }

--- a/example-applications/iot-lifx-controller/src/main/java/com/timmattison/lifx/BasicLifxController.java
+++ b/example-applications/iot-lifx-controller/src/main/java/com/timmattison/lifx/BasicLifxController.java
@@ -2,6 +2,7 @@ package com.timmattison.lifx;
 
 import com.google.gson.Gson;
 import com.timmattison.configuration.Configuration;
+import com.timmattison.configuration.SceneRotatorPersistence;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
@@ -21,10 +22,12 @@ import java.util.Map;
  */
 public class BasicLifxController implements LifxController {
     private final Configuration configuration;
+    private final SceneRotatorPersistence sceneRotatorPersistence;
 
     @Inject
-    public BasicLifxController(Configuration configuration) {
+    public BasicLifxController(Configuration configuration, SceneRotatorPersistence sceneRotatorPersistence) {
         this.configuration = configuration;
+        this.sceneRotatorPersistence = sceneRotatorPersistence;
     }
 
     public void activateScene(Scene scene) throws IOException {
@@ -113,7 +116,21 @@ public class BasicLifxController implements LifxController {
             return;
         }
 
+        SceneList sceneList = action.getSceneList();
+
+        // Is there a list of states?
+        if (sceneList != null) {
+            // Yes, set the next scene
+            setSceneFromSceneList(sceneList);
+            return;
+        }
+
         // Action not understood, throw an exception
         throw new UnsupportedOperationException("Invalid action");
+    }
+
+    private void setSceneFromSceneList(SceneList sceneList) throws IOException {
+        // Get the next scene from our scene list and activate it
+        activateScene(sceneRotatorPersistence.getNextScene(sceneList));
     }
 }

--- a/example-applications/iot-lifx-controller/src/main/java/com/timmattison/lifx/SceneList.java
+++ b/example-applications/iot-lifx-controller/src/main/java/com/timmattison/lifx/SceneList.java
@@ -1,0 +1,39 @@
+package com.timmattison.lifx;
+
+import com.typesafe.config.ConfigList;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by timmattison on 10/16/15.
+ */
+public class SceneList {
+    private final ConfigList data;
+    private List<String> scenes;
+
+    public SceneList(ConfigList data) {
+        this.data = data;
+    }
+
+    public List<String> getScenes() {
+        if (scenes == null) {
+            scenes = new ArrayList<String>();
+
+            for (Object object : data.unwrapped()) {
+                scenes.add((String) object);
+            }
+        }
+
+        return scenes;
+    }
+
+    public ConfigList getData() {
+        return data;
+    }
+
+    @Override
+    public int hashCode() {
+        return getScenes().hashCode();
+    }
+}

--- a/example-applications/iot-lifx-controller/src/main/resources/application.json.example
+++ b/example-applications/iot-lifx-controller/src/main/resources/application.json.example
@@ -5,10 +5,13 @@
   },
   "button": {
     "singleClickAction": {
-      "scene": "YOUR_SCENE_ID_1"
+      "scenes": [
+        "YOUR_SCENE_ID_1",
+        "YOUR_SCENE_ID_2"
+      ]
     },
     "doubleClickAction": {
-      "scene": "YOUR_SCENE_ID_2"
+      "scene": "YOUR_SCENE_ID_3"
     },
     "longClickAction": {
       "state": {

--- a/example-applications/iot-lifx-controller/src/test/java/com/timmattison/ClickTest.java
+++ b/example-applications/iot-lifx-controller/src/test/java/com/timmattison/ClickTest.java
@@ -1,6 +1,7 @@
 package com.timmattison;
 
 import com.timmattison.button.ClickType;
+import com.timmattison.configuration.BasicSceneRotatorPersistence;
 import com.timmattison.configuration.Configuration;
 import com.timmattison.configuration.ConfigurationFromTypeSafe;
 import com.timmattison.lifx.*;
@@ -32,7 +33,7 @@ public abstract class ClickTest {
     @Before
     public void setup() {
         configuration = new ConfigurationFromTypeSafe();
-        lifxController = new BasicLifxController(configuration);
+        lifxController = new BasicLifxController(configuration, new BasicSceneRotatorPersistence());
     }
 
     @Test
@@ -43,12 +44,14 @@ public abstract class ClickTest {
     }
 
     @Test
-    public void clickActionStateOrSceneShouldNotBeNull() {
+    public void clickActionStateSceneOrSceneListShouldNotBeNull() {
         Action action = configuration.getAction(getClickType());
         Scene scene = action.getScene();
         State state = action.getState();
+        SceneList sceneList = action.getSceneList();
 
-        Assert.assertTrue("Either state or scene must be set", ((scene != null) || (state != null)));
+        Assert.assertTrue("Either state, scene, or scene list must be set",
+                ((scene != null) || (state != null) || (sceneList != null)));
     }
 
     @Test


### PR DESCRIPTION
This PR implements a "simple" scene rotator.  That means that one button will iterate through a list of scenes.  To do this it uses AWS SQS as what I can only think to call a "datum base" since it holds a single piece of data.

The data it holds is the very last scene that was called.  It uses that to determine the next scene to activate, activates that scene, and then puts its ID into the queue.

I'm actively testing this now.
